### PR TITLE
Fix DB name in config

### DIFF
--- a/include/config.php
+++ b/include/config.php
@@ -2,7 +2,7 @@
 $host = 'localhost';
 $user = 'root';
 $pass = '';
-$db = 'Codify';
+$db = 'freelancing_platform';
 $port = 3306;
 $site = 'Codify';
 $logo = 'assets/logo.png';

--- a/php/config.php
+++ b/php/config.php
@@ -3,7 +3,7 @@
 $host = 'localhost';
 $user = 'codiwoob_hassan';
 $pass = 'Sk@teordie2016';
-$db = 'Codify';
+$db = 'freelancing_platform';
 $port = "3306";
 $site = 'Codify';
 
@@ -12,8 +12,8 @@ $favicon = 'asset/favicon.ico';
 
 
 
-$conn = new mysqli($host, $user, $pass, "codiwoob_Codify", $port);
-$mysqli = new mysqli($host, $user, $pass, "codiwoob_Codify", $port);
+$conn = new mysqli($host, $user, $pass, $db, $port);
+$mysqli = new mysqli($host, $user, $pass, $db, $port);
 
 if ($mysqli->connect_errno) {
     echo 'Connect Error ('.$mysqli->connect_errno.') '.$mysqli->connect_error;


### PR DESCRIPTION
## Summary
- point `include/config.php` and `php/config.php` to the `freelancing_platform` database
- use `$db` variable when creating mysqli connections

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a0493bfcc832fa1f35b4fe0592c49