### PR TITLE
Auto initialize DB schema

### DIFF
--- a/include/config.php
+++ b/include/config.php
@@ -13,4 +13,8 @@ $mysqli = $conn;
 if ($mysqli->connect_errno) {
     die('Connect Error (' . $mysqli->connect_errno . ') ' . $mysqli->connect_error);
 }
+
+// Automatically initialize database schema if tables are missing
+require_once __DIR__ . '/init_db.php';
+initializeDatabase($mysqli, dirname(__DIR__) . '/db/schema.sql');
 ?>

--- a/include/header.php
+++ b/include/header.php
@@ -6,13 +6,17 @@ $username = '';
 if (isset($_SESSION['USER_ID'])) {
     $uid = $_SESSION['USER_ID'];
     if (isset($mysqli)) {
-        $stmt = $mysqli->prepare('SELECT name FROM users WHERE id=?');
+        $stmt = $mysqli->prepare('SELECT * FROM users WHERE id=?');
         if ($stmt) {
             $stmt->bind_param('i', $uid);
             $stmt->execute();
             $res = $stmt->get_result();
             if ($row = $res->fetch_assoc()) {
-                $username = $row['name'];
+                if (isset($row['name'])) {
+                    $username = $row['name'];
+                } elseif (isset($row['username'])) {
+                    $username = $row['username'];
+                }
             }
             $stmt->close();
         }

--- a/include/init_db.php
+++ b/include/init_db.php
@@ -1,0 +1,18 @@
+<?php
+function initializeDatabase(mysqli $mysqli, string $schemaPath): void {
+    $result = $mysqli->query("SHOW TABLES LIKE 'users'");
+    if (!$result || $result->num_rows === 0) {
+        if (!file_exists($schemaPath)) {
+            return; // schema missing
+        }
+        $sql = file_get_contents($schemaPath);
+        if ($sql !== false) {
+            $mysqli->multi_query($sql);
+            // flush multi queries
+            while ($mysqli->more_results()) {
+                $mysqli->next_result();
+            }
+        }
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- automatically load the SQL schema if tables are missing
- make header.php more tolerant when retrieving the user name

## Testing
- `php -l include/init_db.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c72663aa8832f9854f7b01fddb2e2