### PR TITLE
Fix chat link

### DIFF
--- a/projects/projects.php
+++ b/projects/projects.php
@@ -63,7 +63,7 @@ $row3 = $result3 && $result3->num_rows ? $result3->fetch_assoc() : null;
             </div>
             <div class="job-card-buttons">
                 <a class="btn" href="../projects.php?pid=<?=$row['id']?>">Apply Now</a>
-                <a class="btn" href="../users.php?pid=<?=$row['id']?>&cid=<?=$row['cid']?>">php chat</a>
+                <a class="btn" href="../users.php?pid=<?=$row['id']?>&cid=<?=$row['user_id']?>">php chat</a>
             </div>
         </div>
 <?php } ?>


### PR DESCRIPTION
## Summary
- fix php notice near Apply Now by correcting chat link

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9fa3e1fc832f9102002bf3a788ea