### PR TITLE
Fix chat link label

### DIFF
--- a/projects/projects.php
+++ b/projects/projects.php
@@ -63,7 +63,7 @@ $row3 = $result3 && $result3->num_rows ? $result3->fetch_assoc() : null;
             </div>
             <div class="job-card-buttons">
                 <a class="btn" href="../projects.php?pid=<?=$row['id']?>">Apply Now</a>
-                <a class="btn" href="../users.php?pid=<?=$row['id']?>&cid=<?=$row['user_id']?>">php chat</a>
+                <a class="btn" href="../users.php?pid=<?=$row['id']?>&cid=<?=$row['user_id']?>">Chat</a>
             </div>
         </div>
 <?php } ?>


### PR DESCRIPTION
## Summary
- rename the "php chat" button to a simpler "Chat" label

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ca14ca820832fb93f6c9f63a66798