### PR TITLE
Fix missing column error in project query

### DIFF
--- a/projects.php
+++ b/projects.php
@@ -20,7 +20,7 @@ $uid = $_SESSION['USER_ID'];
 $pid = (int) @$_GET['pid'];
 
 
-$result = $mysqli->query("SELECT p.`id`, p.`title`, p.`description`, p.`budget`, u.`name` AS `client_name`
+$result = $mysqli->query("SELECT p.`id`, p.`title`, p.`description`, p.`budget`, u.`username` AS `client_name`
     FROM `projects` p JOIN `users` u ON p.user_id = u.id WHERE p.`id` = $pid");
 
 


### PR DESCRIPTION
## Summary
- fix SQL query to use `username` column instead of `name`

## Testing
- `php -l projects.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684cab96df44832f98ea150ca93d5628