### PR TITLE
Add project-based messaging

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -12,6 +12,7 @@
       <header>
         <?php 
           $user_id = mysqli_real_escape_string($conn, $_GET['user_id']);
+          $project_id = intval($_GET['pid'] ?? ($_SESSION['pid'] ?? 0));
           $sql = mysqli_query($conn, "SELECT * FROM mssgusers WHERE unique_id = {$user_id}");
           if(mysqli_num_rows($sql) > 0){
             $row = mysqli_fetch_assoc($sql);
@@ -32,6 +33,7 @@
       </div>
       <form action="#" class="typing-area">
         <input type="text" class="incoming_id" name="incoming_id" value="<?php echo $user_id; ?>" hidden>
+        <input type="text" class="project_id" name="project_id" value="<?php echo $project_id; ?>" hidden>
         <input type="text" name="message" class="input-field" placeholder="Type a message here..." autocomplete="off">
         <button><i class="fab fa-telegram-plane"></i></button>
       </form>

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -62,12 +62,14 @@ CREATE TABLE IF NOT EXISTS mssgusers (
 );
 
 CREATE TABLE IF NOT EXISTS messages (
-    msg_id INT AUTO_INCREMENT PRIMARY KEY,
-    incoming_msg_id INT NOT NULL,
-    outgoing_msg_id INT NOT NULL,
-    msg TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (incoming_msg_id) REFERENCES mssgusers(unique_id) ON DELETE CASCADE,
-    FOREIGN KEY (outgoing_msg_id) REFERENCES mssgusers(unique_id) ON DELETE CASCADE
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    project_id INT,
+    sender_id INT NOT NULL,
+    receiver_id INT NOT NULL,
+    content TEXT NOT NULL,
+    sent_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
+    FOREIGN KEY (sender_id) REFERENCES mssgusers(unique_id) ON DELETE CASCADE,
+    FOREIGN KEY (receiver_id) REFERENCES mssgusers(unique_id) ON DELETE CASCADE
 );
 

--- a/javascript/chat.js
+++ b/javascript/chat.js
@@ -1,0 +1,41 @@
+const form = document.querySelector(".typing-area"),
+      incoming_id = form.querySelector(".incoming_id").value,
+      project_id = form.querySelector(".project_id").value,
+      inputField = form.querySelector(".input-field"),
+      chatBox = document.querySelector(".chat-box");
+
+form.onsubmit = (e)=>{
+    e.preventDefault();
+};
+
+form.querySelector("button").onclick = ()=>{
+    let xhr = new XMLHttpRequest();
+    xhr.open("POST", "php/send-message.php", true);
+    xhr.onload = ()=>{
+        if(xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200){
+            inputField.value = "";
+            scrollToBottom();
+        }
+    };
+    let formData = new FormData(form);
+    formData.append("project_id", project_id);
+    xhr.send(formData);
+};
+
+setInterval(()=>{
+    let xhr = new XMLHttpRequest();
+    xhr.open("POST", "php/get-chat.php", true);
+    xhr.onload = ()=>{
+        if(xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200){
+            chatBox.innerHTML = xhr.response;
+            scrollToBottom();
+        }
+    };
+    let formData = new FormData(form);
+    formData.append("project_id", project_id);
+    xhr.send(formData);
+}, 500);
+
+function scrollToBottom(){
+    chatBox.scrollTop = chatBox.scrollHeight;
+}

--- a/php/data.php
+++ b/php/data.php
@@ -1,14 +1,14 @@
 <?php
     while($row = mysqli_fetch_assoc($query)){
-        $sql2 = "SELECT * FROM messages WHERE (incoming_msg_id = {$row['unique_id']}
-                OR outgoing_msg_id = {$row['unique_id']}) AND (outgoing_msg_id = {$outgoing_id} 
-                OR incoming_msg_id = {$outgoing_id}) ORDER BY msg_id DESC LIMIT 1";
+        $pid = intval($_SESSION['pid'] ?? 0);
+        $sql2 = "SELECT * FROM messages WHERE project_id={$pid} AND ((sender_id = {$row['unique_id']} AND receiver_id = {$outgoing_id})
+                OR (sender_id = {$outgoing_id} AND receiver_id = {$row['unique_id']})) ORDER BY id DESC LIMIT 1";
         $query2 = mysqli_query($conn, $sql2);
         $row2 = mysqli_fetch_assoc($query2);
-        (mysqli_num_rows($query2) > 0) ? $result = $row2['msg'] : $result ="No message available";
+        (mysqli_num_rows($query2) > 0) ? $result = $row2['content'] : $result ="No message available";
         (strlen($result) > 28) ? $msg =  substr($result, 0, 28) . '...' : $msg = $result;
-        if(isset($row2['outgoing_msg_id'])){
-            ($outgoing_id == $row2['outgoing_msg_id']) ? $you = "You: " : $you = "";
+        if(isset($row2['sender_id'])){
+            ($outgoing_id == $row2['sender_id']) ? $you = "You: " : $you = "";
         }else{
             $you = "";
         }

--- a/php/get-chat.php
+++ b/php/get-chat.php
@@ -4,24 +4,25 @@
         include_once "config.php";
         $outgoing_id = $_SESSION['unique_id'];
         $incoming_id = mysqli_real_escape_string($conn, $_POST['incoming_id']);
+        $project_id  = intval($_POST['project_id'] ?? 0);
         $output = "";
-        $sql = "SELECT * FROM messages LEFT JOIN mssgusers ON mssgusers.unique_id = messages.outgoing_msg_id
-                WHERE (outgoing_msg_id = {$outgoing_id} AND incoming_msg_id = {$incoming_id})
-                OR (outgoing_msg_id = {$incoming_id} AND incoming_msg_id = {$outgoing_id}) ORDER BY msg_id";
+        $sql = "SELECT messages.*, mssgusers.img FROM messages LEFT JOIN mssgusers ON mssgusers.unique_id = messages.sender_id
+                WHERE project_id = {$project_id} AND ((sender_id = {$outgoing_id} AND receiver_id = {$incoming_id})
+                OR (sender_id = {$incoming_id} AND receiver_id = {$outgoing_id})) ORDER BY id";
         $query = mysqli_query($conn, $sql);
         if(mysqli_num_rows($query) > 0){
             while($row = mysqli_fetch_assoc($query)){
-                if($row['outgoing_msg_id'] === $outgoing_id){
+                if($row['sender_id'] == $outgoing_id){
                     $output .= '<div class="chat outgoing">
                                 <div class="details">
-                                    <p>'. $row['msg'] .'</p>
+                                    <p>'. htmlspecialchars($row['content']) .'</p>
                                 </div>
                                 </div>';
                 }else{
                     $output .= '<div class="chat incoming">
-                                <img src="php/images/'.$row['img'].'" alt="">
+                                <img src="php/images/'. $row['img'] .'" alt="">
                                 <div class="details">
-                                    <p>'. $row['msg'] .'</p>
+                                    <p>'. htmlspecialchars($row['content']) .'</p>
                                 </div>
                                 </div>';
                 }

--- a/php/send-message.php
+++ b/php/send-message.php
@@ -1,0 +1,13 @@
+<?php
+session_start();
+if(isset($_SESSION['unique_id'])){
+    include_once "config.php";
+    $sender_id = $_SESSION['unique_id'];
+    $receiver_id = mysqli_real_escape_string($conn, $_POST['incoming_id']);
+    $project_id = intval($_POST['project_id'] ?? 0);
+    $message = mysqli_real_escape_string($conn, $_POST['message']);
+    if(!empty($message)){
+        $sql = mysqli_query($conn, "INSERT INTO messages (project_id, sender_id, receiver_id, content) VALUES ({$project_id}, {$sender_id}, {$receiver_id}, '{$message}')");
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- update `messages` table schema
- add project-based message insertion endpoint
- modify chat retrieval to filter by project
- show project ID in chat form
- implement simple chat frontend script

## Testing
- `php` command not found, so no syntax checks run

------
https://chatgpt.com/codex/tasks/task_e_68509b070288832fb81a759880a5313e