### PR TITLE
Fix project details query

### DIFF
--- a/projects.php
+++ b/projects.php
@@ -20,7 +20,7 @@ $uid = $_SESSION['USER_ID'];
 $pid = (int) @$_GET['pid'];
 
 
-$result = $mysqli->query("SELECT p.`id`, p.`title`, p.`description`, p.`budget`, u.`username` AS `client_name`
+$result = $mysqli->query("SELECT p.`id`, p.`title`, p.`description`, p.`budget`, u.`name` AS `client_name`
     FROM `projects` p JOIN `users` u ON p.user_id = u.id WHERE p.`id` = $pid");
 
 


### PR DESCRIPTION
## Summary
- use the correct `name` field when retrieving project information

## Testing
- `php -l projects.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850a1efc094832fb7c7e56f521e7981