### PR TITLE
Fix project details query

### DIFF
--- a/projects.php
+++ b/projects.php
@@ -20,8 +20,14 @@ $uid = $_SESSION['USER_ID'];
 $pid = (int) @$_GET['pid'];
 
 
-$result = $mysqli->query("SELECT p.`id`, p.`title`, p.`description`, p.`budget`, u.`username` AS `client_name`
-    FROM `projects` p JOIN `users` u ON p.user_id = u.id WHERE p.`id` = $pid");
+// Retrieve project details and client name. Some deployments may use
+// either a `name` or `username` field for the user table, so use
+// COALESCE to support both without errors.
+$result = $mysqli->query(
+    "SELECT p.`id`, p.`title`, p.`description`, p.`budget`, " .
+    "COALESCE(u.`name`, u.`username`) AS `client_name` " .
+    "FROM `projects` p JOIN `users` u ON p.user_id = u.id WHERE p.`id` = $pid"
+);
 
 
 // Determine the hired freelancer for this project, if any


### PR DESCRIPTION
## Summary
- use COALESCE to support name or username field when retrieving project owner info

## Testing
- `php -l projects.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850a1efc094832fb7c7e56f521e7981