### PR TITLE
Fix project details query

### DIFF
--- a/projects.php
+++ b/projects.php
@@ -20,8 +20,16 @@ $uid = $_SESSION['USER_ID'];
 $pid = (int) @$_GET['pid'];
 
 
-$result = $mysqli->query("SELECT p.`id`, p.`title`, p.`description`, p.`budget`, u.`username` AS `client_name`
-    FROM `projects` p JOIN `users` u ON p.user_id = u.id WHERE p.`id` = $pid");
+// Retrieve project details and client name. Some installations might
+// have either a `name` or a `username` column in the `users` table.
+// Check which one exists to avoid SQL errors with missing columns.
+$columnCheck = $mysqli->query("SHOW COLUMNS FROM `users` LIKE 'name'");
+$userNameField = ($columnCheck && $columnCheck->num_rows) ? 'name' : 'username';
+$result = $mysqli->query(
+    "SELECT p.`id`, p.`title`, p.`description`, p.`budget`, " .
+    "u.`$userNameField` AS `client_name` " .
+    "FROM `projects` p JOIN `users` u ON p.user_id = u.id WHERE p.`id` = $pid"
+);
 
 
 // Determine the hired freelancer for this project, if any


### PR DESCRIPTION
## Summary
- detect whether `users` table uses `name` or `username` to fetch client name

## Testing
- `php -l projects.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850a1efc094832fb7c7e56f521e7981