### PR TITLE
Add proposal form and favorites

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -73,3 +73,12 @@ CREATE TABLE IF NOT EXISTS messages (
     FOREIGN KEY (receiver_id) REFERENCES mssgusers(unique_id) ON DELETE CASCADE
 );
 
+
+CREATE TABLE IF NOT EXISTS favorites (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    project_id INT NOT NULL,
+    UNIQUE KEY user_project (user_id, project_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);

--- a/include/favorite.php
+++ b/include/favorite.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__.'/db.php';
+
+$pid = intval($_POST['pid'] ?? 0);
+$uid = $_SESSION['USER_ID'] ?? 0;
+
+if ($pid && $uid) {
+    $stmt = $mysqli->prepare('SELECT id FROM favorites WHERE user_id=? AND project_id=?');
+    if ($stmt) {
+        $stmt->bind_param('ii', $uid, $pid);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        if ($res && $res->num_rows) {
+            $del = $mysqli->prepare('DELETE FROM favorites WHERE user_id=? AND project_id=?');
+            if ($del) {
+                $del->bind_param('ii', $uid, $pid);
+                $del->execute();
+            }
+        } else {
+            $ins = $mysqli->prepare('INSERT INTO favorites (user_id, project_id) VALUES (?,?)');
+            if ($ins) {
+                $ins->bind_param('ii', $uid, $pid);
+                $ins->execute();
+            }
+        }
+    }
+}
+header('Location: ../projects.php?pid=' . $pid);
+exit;
+?>

--- a/include/init_db.php
+++ b/include/init_db.php
@@ -7,7 +7,8 @@ function initializeDatabase(mysqli $mysqli, string $schemaPath): void {
         'projects',
         'post_req',
         'mssgusers',
-        'messages'
+        'messages',
+        'favorites'
     ];
 
     $missing = false;


### PR DESCRIPTION
## Summary
- enable DB initialization for new `favorites` table
- allow watching projects via new `include/favorite.php`
- display attachments, bid form and favorite button on project page
- update schema with `favorites` table

## Testing
- `php -l projects.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685146edb4d8832fb98a352d275f9fbd