### PR TITLE
Add client contact fields and project contact option

### DIFF
--- a/client.php
+++ b/client.php
@@ -122,6 +122,8 @@ $row8 = $result8->fetch_assoc();?>
                 <div class="item header-text">
 
                   <h2>Dashboard <br><em>Client</em></h2> <br> <br>
+                  <p>Adresse: <?= htmlspecialchars($rowss['address'] ?? '') ?><br>
+                  Téléphone: <?= htmlspecialchars($rowss['phone'] ?? '') ?></p>
                   <div class="down-buttons">
                     <div class="main-blue-button-hover">
                       <a href="#services">Voir Missions </a>

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -12,6 +12,8 @@ CREATE TABLE IF NOT EXISTS client (
     cid INT PRIMARY KEY,
     sec VARCHAR(100),
     serv VARCHAR(100),
+    address VARCHAR(255),
+    phone VARCHAR(20),
     FOREIGN KEY (cid) REFERENCES users(id) ON DELETE CASCADE
 );
 

--- a/include/add-user.php
+++ b/include/add-user.php
@@ -11,6 +11,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($stmt) {
         $stmt->bind_param('ssss', $name, $email, $password, $type);
         $stmt->execute();
+        $uid = $mysqli->insert_id;
+        if ($type === 'client') {
+            $sec     = trim($_POST['sec'] ?? '');
+            $serv    = trim($_POST['serv'] ?? '');
+            $address = trim($_POST['address'] ?? '');
+            $phone   = trim($_POST['phone'] ?? '');
+            $cstmt = $mysqli->prepare('INSERT INTO client (cid, sec, serv, address, phone) VALUES (?,?,?,?,?)');
+            if ($cstmt) {
+                $cstmt->bind_param('issss', $uid, $sec, $serv, $address, $phone);
+                $cstmt->execute();
+            }
+        }
     }
     $_SESSION['msg'] = ['type' => 'success', 'msg' => 'Account created'];
     header('Location: ../login.php');

--- a/projects.php
+++ b/projects.php
@@ -13,8 +13,13 @@ if (!$pid) {
 }
 
 $stmt = $mysqli->prepare(
-    "SELECT p.id, p.title, p.description, p.budget, p.deadline, p.status, p.created_at, u.username AS client_name, u.email AS client_email
-     FROM projects p JOIN users u ON p.user_id = u.id WHERE p.id = ?"
+    "SELECT p.id, p.title, p.description, p.budget, p.deadline, p.status, p.created_at,
+            u.username AS client_name, u.email AS client_email,
+            c.address, c.phone
+     FROM projects p
+     JOIN users u ON p.user_id = u.id
+     LEFT JOIN client c ON u.id = c.cid
+     WHERE p.id = ?"
 );
 $stmt->bind_param('i', $pid);
 $stmt->execute();
@@ -40,6 +45,7 @@ $row = $result->fetch_assoc();
     </style>
 </head>
 <body>
+<?php require 'include/header.php'; ?>
 <div class="container">
     <h1 class="project-title"><?= htmlspecialchars($row['title']) ?></h1>
     <div class="project-meta">
@@ -49,7 +55,18 @@ $row = $result->fetch_assoc();
         <span>Status: <?= htmlspecialchars($row['status']) ?></span>
         <span>Posted on: <?= htmlspecialchars($row['created_at']) ?></span>
     </div>
+    <button id="contactBtn">Voir les coordonnées du client</button>
+    <div id="contactInfo" style="display:none; margin-top:10px;">
+        <p>Adresse: <?= htmlspecialchars($row['address'] ?? '') ?></p>
+        <p>Téléphone: <?= htmlspecialchars($row['phone'] ?? '') ?></p>
+    </div>
     <div class="project-description"><?= htmlspecialchars($row['description']) ?></div>
 </div>
+<script>
+document.getElementById('contactBtn').addEventListener('click', function(){
+    var info = document.getElementById('contactInfo');
+    info.style.display = info.style.display === 'none' ? 'block' : 'none';
+});
+</script>
 </body>
 </html>

--- a/signup.php
+++ b/signup.php
@@ -156,12 +156,18 @@ if (isset($_SESSION['USER_ID']) && !empty($_SESSION['USER_ID'])) {
                                          </select>
                                          <br>
 
-                                        
-                                        
-                                    </div>
-                                </div>
-                                </div>
-                            </div>
+                                     </div> <br> <br>
+                                     <div class="q-box__question">
+                                         <label class="" for="address">Adresse :</label> <br>
+                                         <input required class="" id="address" name="address" type="text">
+                                     </div> <br> <br>
+                                     <div class="q-box__question">
+                                         <label class="" for="phone">Numéro de téléphone :</label> <br>
+                                         <input required class="" id="phone" name="phone" type="text">
+                                     </div>
+                                     </div>
+                                 </div>
+                                 </div>
                             
                         </div>
                         <div id="q-box__buttons">


### PR DESCRIPTION
## Summary
- support client address and phone number in schema and signup
- store client contact info in `add-user.php`
- show contact info in client dashboard
- add header and contact reveal button on project detail page

## Testing
- `npm test` *(fails: Missing script and offline)*

------
https://chatgpt.com/codex/tasks/task_e_68514fdbb8ac832f9f48032d71796db2