### PR TITLE
Fix client signup when address column absent

### DIFF
--- a/include/add-user.php
+++ b/include/add-user.php
@@ -26,10 +26,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $serv    = trim($_POST['serv'] ?? '');
             $address = trim($_POST['address'] ?? '');
             $phone   = trim($_POST['phone'] ?? '');
-            $cstmt = $mysqli->prepare('INSERT INTO client (cid, sec, serv, address, phone) VALUES (?,?,?,?,?)');
-            if ($cstmt) {
-                $cstmt->bind_param('issss', $uid, $sec, $serv, $address, $phone);
-                $cstmt->execute();
+
+            // Check if the `client` table contains an `address` column.
+            $addrCol = $mysqli->query("SHOW COLUMNS FROM client LIKE 'address'");
+
+            if ($addrCol && $addrCol->num_rows > 0) {
+                $cstmt = $mysqli->prepare('INSERT INTO client (cid, sec, serv, address, phone) VALUES (?,?,?,?,?)');
+                if ($cstmt) {
+                    $cstmt->bind_param('issss', $uid, $sec, $serv, $address, $phone);
+                    $cstmt->execute();
+                }
+            } else {
+                $cstmt = $mysqli->prepare('INSERT INTO client (cid, sec, serv, phone) VALUES (?,?,?,?)');
+                if ($cstmt) {
+                    $cstmt->bind_param('isss', $uid, $sec, $serv, $phone);
+                    $cstmt->execute();
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add detection for `address` column before inserting into `client` table

## Testing
- `php -l include/add-user.php` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685155c86224832f87a58a7f62a8d7ce