### PR TITLE
Fix user signup fields

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -5,7 +5,11 @@ CREATE TABLE IF NOT EXISTS users (
     name VARCHAR(100) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
     password VARCHAR(255) NOT NULL,
-    type VARCHAR(20) NOT NULL DEFAULT 'client'
+    type VARCHAR(20) NOT NULL DEFAULT 'client',
+    phone VARCHAR(20),
+    address VARCHAR(255),
+    profile_img VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS client (

--- a/include/add-user.php
+++ b/include/add-user.php
@@ -2,10 +2,26 @@
 require_once __DIR__.'/db.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $name = trim($_POST['name'] ?? '');
-    $email = trim($_POST['email'] ?? '');
+    $name    = trim($_POST['name'] ?? '');
+    $email   = trim($_POST['email'] ?? '');
     $password = password_hash($_POST['password'] ?? '', PASSWORD_BCRYPT);
-    $type = $_POST['usertype'] ?? 'client';
+    $type    = $_POST['usertype'] ?? 'client';
+    $address = trim($_POST['address'] ?? '');
+    $phone   = trim($_POST['phone'] ?? '');
+
+    $imgName = null;
+    if (!empty($_FILES['image']['name'])) {
+        $targetDir = dirname(__DIR__) . '/php/images/';
+        if (!file_exists($targetDir)) {
+            mkdir($targetDir, 0777, true);
+        }
+        $base = basename($_FILES['image']['name']);
+        $imgName = time() . $base;
+        $path = $targetDir . $imgName;
+        if (!move_uploaded_file($_FILES['image']['tmp_name'], $path)) {
+            $imgName = null;
+        }
+    }
 
     // Determine if the `users` table uses the column `name` or `username` for the
     // user's display name. Some deployments still contain a legacy `username`
@@ -16,16 +32,53 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $nameColumn = 'username';
     }
 
-    $stmt = $mysqli->prepare("INSERT INTO users (`$nameColumn`, email, password, type) VALUES (?,?,?,?)");
+    $columns = "`$nameColumn`, email, password, type";
+    $placeholders = "?,?,?,?";
+    $typesBind = "ssss";
+    $params = [$name, $email, $password, $type];
+
+    $checkPhone = $mysqli->query("SHOW COLUMNS FROM users LIKE 'phone'");
+    if ($checkPhone && $checkPhone->num_rows > 0) {
+        $columns .= ", phone";
+        $placeholders .= ",?";
+        $typesBind .= "s";
+        $params[] = $phone;
+    }
+    $checkAddr = $mysqli->query("SHOW COLUMNS FROM users LIKE 'address'");
+    if ($checkAddr && $checkAddr->num_rows > 0) {
+        $columns .= ", address";
+        $placeholders .= ",?";
+        $typesBind .= "s";
+        $params[] = $address;
+    }
+    $checkImg = $mysqli->query("SHOW COLUMNS FROM users LIKE 'profile_img'");
+    if ($checkImg && $checkImg->num_rows > 0) {
+        $columns .= ", profile_img";
+        $placeholders .= ",?";
+        $typesBind .= "s";
+        $params[] = $imgName;
+    }
+
+    $stmt = $mysqli->prepare("INSERT INTO users ($columns) VALUES ($placeholders)");
     if ($stmt) {
-        $stmt->bind_param('ssss', $name, $email, $password, $type);
+        $stmt->bind_param($typesBind, ...$params);
         $stmt->execute();
         $uid = $mysqli->insert_id;
+
+        // create messaging user profile
         if ($type === 'client') {
-            $sec     = trim($_POST['sec'] ?? '');
-            $serv    = trim($_POST['serv'] ?? '');
-            $address = trim($_POST['address'] ?? '');
-            $phone   = trim($_POST['phone'] ?? '');
+            $msgStmt = $mysqli->prepare('INSERT INTO mssgusers (cid, name, img) VALUES (?,?,?)');
+        } else {
+            $msgStmt = $mysqli->prepare('INSERT INTO mssgusers (fid, name, img) VALUES (?,?,?)');
+        }
+        if ($msgStmt) {
+            $msgStmt->bind_param('iss', $uid, $name, $imgName);
+            $msgStmt->execute();
+        }
+
+        if ($type === 'client') {
+            $sec  = trim($_POST['sec'] ?? '');
+            $serv = trim($_POST['serv'] ?? '');
 
             // Check if the `client` table contains an `address` column.
             $addrCol = $mysqli->query("SHOW COLUMNS FROM client LIKE 'address'");


### PR DESCRIPTION
## Summary
- include optional phone/address/profile image fields when signing up
- support these columns in `users` table via schema update
- save user profile image and register chat user record

## Testing
- `php -l include/add-user.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851583138e0832f87a587d7406a3cca