### PR TITLE
Add profile page and show client info

### DIFF
--- a/client.php
+++ b/client.php
@@ -91,7 +91,8 @@ $row8 = $result8->fetch_assoc();?>
               <li class="scroll-to-section"><a href="#top" class="active"></a></li>
 <li class="scroll-to-section">      <img class="user-profile" src="php/images/<?php echo $row8['img']?>" alt=""></li>
               <li class="scroll-to-section"><a href="#video"></a></li> 
-              <li class="scroll-to-section"><a href="#contact"><?php echo $rowss['name'] ?></a></li> 
+              <li class="scroll-to-section"><a href="profile.php?uid=<?=$cid?>">Profil</a></li>
+              <li class="scroll-to-section"><a href="#contact"><?php echo $rowss['name'] ?></a></li>
               <li class="scroll-to-section"><div class="main-red-button-hover"><a href="include/logout.php">Logout</a></div></li> 
             </ul>
             <a class='menu-trigger'>

--- a/profile.php
+++ b/profile.php
@@ -1,0 +1,59 @@
+<?php
+require 'include/config.php';
+require 'include/db.php';
+
+// Determine which user to display
+$uid = isset($_GET['uid']) ? (int)$_GET['uid'] : ($_SESSION['USER_ID'] ?? 0);
+if (!$uid) {
+    exit('User ID missing.');
+}
+
+$stmt = $mysqli->prepare('SELECT id, name, email, type, phone, address, profile_img, created_at FROM users WHERE id = ?');
+$stmt->bind_param('i', $uid);
+$stmt->execute();
+$user = $stmt->get_result()->fetch_assoc();
+if (!$user) {
+    exit('User not found.');
+}
+
+$projectCount = 0;
+if ($user['type'] === 'client') {
+    $countStmt = $mysqli->prepare('SELECT COUNT(*) FROM projects WHERE user_id = ?');
+    $countStmt->bind_param('i', $uid);
+    $countStmt->execute();
+    $countStmt->bind_result($projectCount);
+    $countStmt->fetch();
+    $countStmt->close();
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Profil utilisateur</title>
+    <style>
+        body {font-family: Arial, sans-serif; margin:20px;}
+        .container {max-width:600px; margin:auto;}
+        .profile-img {width:150px; height:150px; object-fit:cover; border-radius:50%;}
+    </style>
+</head>
+<body>
+<?php require 'include/header.php'; ?>
+<div class="container">
+    <h2><?= htmlspecialchars($user['name']) ?></h2>
+    <?php if (!empty($user['profile_img'])): ?>
+        <img class="profile-img" src="php/images/<?= htmlspecialchars($user['profile_img']) ?>" alt="Profile image">
+    <?php endif; ?>
+    <p>Email: <?= htmlspecialchars($user['email']) ?></p>
+    <p>Type: <?= htmlspecialchars($user['type']) ?></p>
+    <?php if ($user['phone']): ?><p>Téléphone: <?= htmlspecialchars($user['phone']) ?></p><?php endif; ?>
+    <?php if ($user['address']): ?><p>Adresse: <?= htmlspecialchars($user['address']) ?></p><?php endif; ?>
+    <p>Membre depuis: <?= htmlspecialchars($user['created_at']) ?></p>
+    <?php if ($user['type'] === 'client'): ?>
+        <p>Projets publiés: <?= $projectCount ?></p>
+    <?php endif; ?>
+</div>
+<?php require 'include/footer.php'; ?>
+</body>
+</html>

--- a/projects/projects.php
+++ b/projects/projects.php
@@ -43,6 +43,7 @@ $row3 = $result3 && $result3->num_rows ? $result3->fetch_assoc() : null;
     <div class="user-settings">
         <img class="user-profile" src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/3364143/download+%283%29+%281%29.png" alt="">
         <div class="user-name"><?php echo $row3['name'] ?? '' ?></div>
+        <a style="margin-right:10px;" href="../profile.php?uid=<?=$fid?>">Profil</a>
         <a class="logout-link" href="../include/logout.php">Logout</a>
     </div>
 </header>


### PR DESCRIPTION
## Summary
- create `profile.php` to show user details with project count
- show full client info on project detail page
- link to profile from client and freelancer dashboards

## Testing
- `php -l profile.php` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685168476848832f8c101d0e8695b3dc