### PR TITLE
Fix updating project status

### DIFF
--- a/include/update-status.php
+++ b/include/update-status.php
@@ -2,12 +2,15 @@
 require_once __DIR__ . '/db.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $pid = intval($_POST['pid'] ?? 0);
+    $pid    = intval($_POST['pid'] ?? 0);
     $status = trim($_POST['status'] ?? '');
-    if ($pid && $status) {
+
+    $allowedStatuses = ['open', 'in progress', 'completed'];
+
+    if ($pid && in_array($status, $allowedStatuses, true)) {
+        $uid = $_SESSION['USER_ID'] ?? 0;
         $stmt = $mysqli->prepare('UPDATE projects SET status=? WHERE id=? AND user_id=?');
         if ($stmt) {
-            $uid = $_SESSION['USER_ID'] ?? 0;
             $stmt->bind_param('sii', $status, $pid, $uid);
             $stmt->execute();
         }


### PR DESCRIPTION
## Summary
- handle allowed project statuses when updating

## Testing
- `php -l include/update-status.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861bf174508832f841f7d18691e67c1