### PR TITLE
Allow status updates when editing projects

### DIFF
--- a/include/update-post.php
+++ b/include/update-post.php
@@ -6,6 +6,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $title  = trim($_POST['name'] ?? '');
     $desc   = trim($_POST['about'] ?? '');
     $budget = floatval($_POST['cost'] ?? 0);
+    $status = isset($_POST['status']) ? strtolower(trim($_POST['status'])) : null;
     if (!empty($_POST['deadline'])) {
         $ts = strtotime($_POST['deadline']);
         $deadline = $ts ? date('Y-m-d', $ts) : null;
@@ -14,11 +15,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
 
-    $stmt = $mysqli->prepare('UPDATE projects SET title=?, description=?, budget=?, deadline=? WHERE id=?');
-
-    if ($stmt) {
-        $stmt->bind_param('ssdsi', $title, $desc, $budget, $deadline, $pid);
-        $stmt->execute();
+    if ($status !== null && in_array($status, ['open','in progress','completed'], true)) {
+        $stmt = $mysqli->prepare('UPDATE projects SET title=?, description=?, budget=?, deadline=?, status=? WHERE id=?');
+        if ($stmt) {
+            $stmt->bind_param('ssdssi', $title, $desc, $budget, $deadline, $status, $pid);
+            $stmt->execute();
+        }
+    } else {
+        $stmt = $mysqli->prepare('UPDATE projects SET title=?, description=?, budget=?, deadline=? WHERE id=?');
+        if ($stmt) {
+            $stmt->bind_param('ssdsi', $title, $desc, $budget, $deadline, $pid);
+            $stmt->execute();
+        }
     }
 
 

--- a/include/update-status.php
+++ b/include/update-status.php
@@ -16,6 +16,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-header('Location: ../post.php');
+$redirect = '../post.php';
+if (!empty($pid)) {
+    $redirect .= '?pid=' . $pid;
+}
+
+header('Location: ' . $redirect);
 exit;
 ?>

--- a/post.php
+++ b/post.php
@@ -149,6 +149,18 @@ if (empty($_GET['pid'])) {
                                 </div>
                             </div>
                         </div>
+<?php if ($pid): ?>
+                        <div class="form-group">
+                            <div class="col-xs-12 text-danger text-left">
+                                <label for="status" class="text-info">Project status</label>
+                                <select id="status" name="status" class="form-control form-control-line">
+                                    <option value="open" <?= @$row['status']==='open'?'selected':'' ?>>open</option>
+                                    <option value="in progress" <?= @$row['status']==='in progress'?'selected':'' ?>>in progress</option>
+                                    <option value="completed" <?= @$row['status']==='completed'?'selected':'' ?>>completed</option>
+                                </select>
+                            </div>
+                        </div>
+<?php endif; ?>
                         <!--div class="form-group">
                             <div class="col-xs-12 text-danger text-left">
                                 <label for="cost" class="text-info col-form-label">How long would you like to run your contest?</label>


### PR DESCRIPTION
## Summary
- display a project status dropdown in the edit form
- update `update-post.php` to handle optional status changes
- redirect back to the edited project after status updates

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861c559f2b4832fbea375e5638297e4