### PR TITLE
Allow clients to set project status including closed

### DIFF
--- a/include/update-post.php
+++ b/include/update-post.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
 
-    if ($status !== null && in_array($status, ['open','in progress','completed'], true)) {
+    if ($status !== null && in_array($status, ['open','in progress','closed','completed'], true)) {
         $stmt = $mysqli->prepare('UPDATE projects SET title=?, description=?, budget=?, deadline=?, status=? WHERE id=?');
         if ($stmt) {
             $stmt->bind_param('ssdssi', $title, $desc, $budget, $deadline, $status, $pid);

--- a/include/update-status.php
+++ b/include/update-status.php
@@ -5,7 +5,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $pid    = intval($_POST['pid'] ?? 0);
     $status = strtolower(trim($_POST['status'] ?? ''));
 
-    $allowedStatuses = ['open', 'in progress', 'completed'];
+    $allowedStatuses = ['open', 'in progress', 'closed', 'completed'];
 
     if ($pid && in_array($status, $allowedStatuses, true)) {
         $stmt = $mysqli->prepare('UPDATE projects SET status=? WHERE id=?');

--- a/post.php
+++ b/post.php
@@ -156,7 +156,8 @@ if (empty($_GET['pid'])) {
                                 <select id="status" name="status" class="form-control form-control-line">
                                     <option value="open" <?= @$row['status']==='open'?'selected':'' ?>>open</option>
                                     <option value="in progress" <?= @$row['status']==='in progress'?'selected':'' ?>>in progress</option>
-                                    <option value="completed" <?= @$row['status']==='completed'?'selected':'' ?>>completed</option>
+                                    <option value="closed" <?= @$row['status']=='closed'?'selected':'' ?>>closed</option>
+                                    <option value="completed" <?= @$row['status']=='completed'?'selected':'' ?>>completed</option>
                                 </select>
                             </div>
                         </div>
@@ -217,9 +218,10 @@ if (empty($_GET['pid'])) {
                             <form method="post" action="include/update-status.php" class="form-inline">
                                 <input type="hidden" name="pid" value="<?= $p['id'] ?>">
                                 <select name="status" class="form-control form-control-sm mr-2">
-                                    <option value="open" <?= $p['status']==='open'?'selected':'' ?>>open</option>
-                                    <option value="in progress" <?= $p['status']==='in progress'?'selected':'' ?>>in progress</option>
-                                    <option value="completed" <?= $p['status']==='completed'?'selected':'' ?>>completed</option>
+                                                                        <option value="open" <?= $p["status"]=="open"?"selected":"" ?>>open</option>
+                                                                        <option value="in progress" <?= $p["status"]=="in progress"?"selected":"" ?>>in progress</option>
+                                    <option value="closed" <?= $p["status"]=="closed"?"selected":"" ?>>closed</option>
+                                                                        <option value="completed" <?= $p["status"]=="completed"?"selected":"" ?>>completed</option>
                                 </select>
                                 <button type="submit" class="btn btn-sm btn-primary">Update</button>
                             </form>


### PR DESCRIPTION
## Summary
- support `closed` status for projects
- update allowed statuses when editing projects or updating status

## Testing
- `php` lint **(failed: php not installed)**

------
https://chatgpt.com/codex/tasks/task_e_6861cae19758832f864e51f5580c1077