### PR TITLE
Add delete option and streamline project status

### DIFF
--- a/include/update-post.php
+++ b/include/update-post.php
@@ -15,7 +15,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
 
-    if ($status !== null && in_array($status, ['open','in progress','closed','completed'], true)) {
+    $allowedStatuses = ['open', 'closed'];
+    if ($status !== null && in_array($status, $allowedStatuses, true)) {
         $stmt = $mysqli->prepare('UPDATE projects SET title=?, description=?, budget=?, deadline=?, status=? WHERE id=?');
         if ($stmt) {
             $stmt->bind_param('ssdssi', $title, $desc, $budget, $deadline, $status, $pid);

--- a/include/update-status.php
+++ b/include/update-status.php
@@ -5,7 +5,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $pid    = intval($_POST['pid'] ?? 0);
     $status = strtolower(trim($_POST['status'] ?? ''));
 
-    $allowedStatuses = ['open', 'in progress', 'closed', 'completed'];
+    $allowedStatuses = ['open', 'closed'];
 
     if ($pid && in_array($status, $allowedStatuses, true)) {
         $stmt = $mysqli->prepare('UPDATE projects SET status=? WHERE id=?');

--- a/post.php
+++ b/post.php
@@ -165,9 +165,7 @@ if ($pid) {
                                 <label for="status" class="text-info">Statut du projet</label>
                                 <select id="status" name="status" class="form-control form-control-line">
                                     <option value="open" <?= ($row['status'] ?? '')==='open'?'selected':'' ?>>ouvert</option>
-                                    <option value="in progress" <?= ($row['status'] ?? '')==='in progress'?'selected':'' ?>>en cours</option>
                                     <option value="closed" <?= ($row['status'] ?? '')==='closed'?'selected':'' ?>>fermé</option>
-                                    <option value="completed" <?= ($row['status'] ?? '')==='completed'?'selected':'' ?>>terminé</option>
                                 </select>
                             </div>
                         </div>
@@ -229,15 +227,14 @@ if ($pid) {
                                 <input type="hidden" name="pid" value="<?= $p['id'] ?>">
                                 <select name="status" class="form-control form-control-sm mr-2">
                                     <option value="open" <?= $p['status']==='open'?'selected':'' ?>>ouvert</option>
-                                    <option value="in progress" <?= $p['status']==='in progress'?'selected':'' ?>>en cours</option>
                                     <option value="closed" <?= $p['status']==='closed'?'selected':'' ?>>fermé</option>
-                                    <option value="completed" <?= $p['status']==='completed'?'selected':'' ?>>terminé</option>
                                 </select>
                                 <button type="submit" class="btn btn-sm btn-primary">Mettre à jour</button>
                             </form>
                         </td>
                         <td>
                             <a class="btn btn-sm btn-secondary" href="post.php?pid=<?= $p['id'] ?>">Modifier</a>
+                            <a class="btn btn-sm btn-danger" href="include/delete-post.php?pid=<?= $p['id'] ?>" onclick="return confirm('Supprimer ce projet ?');">Supprimer</a>
                         </td>
                     </tr>
                 <?php endwhile; endif; ?>


### PR DESCRIPTION
## Summary
- allow partner client to delete a project from their dashboard
- simplify project status choices to "open" and "closed"

## Testing
- `php -l post.php`
- `php -l include/update-post.php`
- `php -l include/update-status.php`


------
https://chatgpt.com/codex/tasks/task_e_6872e0c86de4832fbf500a8a7744669c