### PR TITLE
Add email verification and reCAPTCHA

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users
+  ADD COLUMN verify_token VARCHAR(128) NULL,
+  ADD COLUMN token_created DATETIME NULL,
+  ADD COLUMN is_verified TINYINT(1) NOT NULL DEFAULT 0;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -9,6 +9,9 @@ CREATE TABLE IF NOT EXISTS users (
     phone VARCHAR(20),
     address VARCHAR(255),
     profile_img VARCHAR(255),
+    verify_token VARCHAR(128),
+    token_created DATETIME,
+    is_verified TINYINT(1) NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/include/check-user.php
+++ b/include/check-user.php
@@ -6,13 +6,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $password = $_POST['password'] ?? '';
     $type = $_POST['usertype'] ?? '';
 
-    $stmt = $mysqli->prepare('SELECT id,password,type FROM users WHERE email = ? LIMIT 1');
+    $stmt = $mysqli->prepare('SELECT id,password,type,is_verified FROM users WHERE email = ? LIMIT 1');
     if ($stmt) {
         $stmt->bind_param('s', $email);
         $stmt->execute();
         $result = $stmt->get_result();
         if ($row = $result->fetch_assoc()) {
-            if (password_verify($password, $row['password'])) {
+            if (!password_verify($password, $row['password'])) {
+                $row = null;
+            }
+            if ($row) {
+                if ((int)$row['is_verified'] !== 1) {
+                    $_SESSION['msg'] = ['type' => 'warning', 'msg' => 'Merci de confirmer votre e-mail'];
+                    header('Location: ../login.php');
+                    exit;
+                }
                 $_SESSION['USER_ID'] = $row['id'];
                 $_SESSION['USER_TYPE'] = $row['type'];
                 if ($row['type'] === 'freelancer') {

--- a/include/config.php
+++ b/include/config.php
@@ -7,6 +7,10 @@ $port = 3306;
 $site = 'CELUT-GC';
 $logo = "img/logo-celutgc.png";
 $favicon = 'assets/favicon.ico';
+$recaptchaSiteKey = 'REPLACE_WITH_SITE_KEY';
+$recaptchaSecretKey = 'REPLACE_WITH_SECRET_KEY';
+$smtpFrom = 'no-reply@example.com';
+$smtpName = 'CELUT-GC';
 
 $conn = new mysqli($host, $user, $pass, $db, $port);
 $mysqli = $conn;

--- a/include/send_verification.php
+++ b/include/send_verification.php
@@ -1,0 +1,32 @@
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+function sendVerificationMail(string $toEmail, string $token, string $from, string $fromName): bool {
+    $mail = new PHPMailer(true);
+    try {
+        // SMTP configuration example - adjust as needed
+        $mail->isSMTP();
+        $mail->Host = 'smtp.example.com';
+        $mail->SMTPAuth = true;
+        $mail->Username = 'user@example.com';
+        $mail->Password = 'secret';
+        $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+        $mail->Port = 587;
+
+        $mail->setFrom($from, $fromName);
+        $mail->addAddress($toEmail);
+
+        $mail->isHTML(true);
+        $mail->Subject = 'Confirm your email';
+        $link = 'http://localhost/verify.php?token=' . urlencode($token);
+        $mail->Body = "<p>Merci de confirmer votre adresse e-mail en cliquant <a href='{$link}'>ici</a>.</p>";
+        $mail->AltBody = "Merci de confirmer votre adresse e-mail: {$link}";
+
+        return $mail->send();
+    } catch (Exception $e) {
+        return false;
+    }
+}

--- a/signup.php
+++ b/signup.php
@@ -174,6 +174,7 @@ if (isset($_SESSION['USER_ID']) && !empty($_SESSION['USER_ID'])) {
                                  </div>
                             
                         </div>
+                        <div class="g-recaptcha mb-3" data-sitekey="<?= $recaptchaSiteKey ?>"></div>
                         <div id="q-box__buttons">
                             <button id="prev-btn" type="button">Previous</button> 
                             <button id="next-btn" type="button" onclick="idk()">Suivant</button>
@@ -211,6 +212,7 @@ if (isset($_SESSION['USER_ID']) && !empty($_SESSION['USER_ID'])) {
             document.getElementById('imageLabel').innerText = "Logo de l'entreprise";
         }}
     </script>
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <script src="signup.js"></script>
 
     <!-- FOOTER -->

--- a/verify.php
+++ b/verify.php
@@ -1,0 +1,38 @@
+<?php
+require 'include/config.php';
+require 'include/db.php';
+require 'include/send_verification.php';
+
+$token = $_GET['token'] ?? '';
+if (!$token) {
+    echo 'Lien invalide';
+    exit;
+}
+
+$stmt = $mysqli->prepare('SELECT id, email, token_created, is_verified FROM users WHERE verify_token = ? LIMIT 1');
+if ($stmt) {
+    $stmt->bind_param('s', $token);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    if ($row = $res->fetch_assoc()) {
+        $created = strtotime($row['token_created']);
+        if ($row['is_verified']) {
+            echo 'Compte déjà vérifié';
+            exit;
+        }
+        if ($created && (time() - $created) <= 86400) {
+            $up = $mysqli->prepare('UPDATE users SET is_verified = 1, verify_token = NULL, token_created = NULL WHERE id = ?');
+            if ($up) {
+                $up->bind_param('i', $row['id']);
+                $up->execute();
+                echo 'Votre compte est désormais vérifié.';
+                exit;
+            }
+        } else {
+            echo 'Token expiré, veuillez demander un nouvel email.';
+            exit;
+        }
+    }
+}
+
+echo 'Lien invalide';


### PR DESCRIPTION
## Summary
- add verification token columns to database
- add helper to send verification email with PHPMailer
- generate token on sign up and send verification email
- block login until email confirmed
- add Google reCAPTCHA to sign-up form
- create verify.php endpoint to validate token

## Testing
- `php -l include/add-user.php`
- `php -l include/check-user.php`
- `php -l verify.php`
- `php -l include/send_verification.php`
- `php -l signup.php`
- `php -l include/config.php`
- Composer install failed due to network restrictions


------
https://chatgpt.com/codex/tasks/task_e_68741b322918832fb0dd431f93532ebe